### PR TITLE
changed absolute data path to relativate

### DIFF
--- a/example/example.ipynb
+++ b/example/example.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,14 +48,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "using DelimitedFiles\n",
-    "cd(\"/Users/nicolaswesseler/Documents/github/ECON622_final_project/TradMod.jl/data\")\n",
-    "DATA = readdlm(\"WIOT08_ROW_Apr12.csv\", ',', Float64)\n",
-    "epsilon = readdlm(\"SECTORAL_TRADE_ELASTICITY.csv\");"
+    "#cd(\"/Users/nicolaswesseler/Documents/github/ECON622_final_project/TradMod.jl/data\")\n",
+    "datadir = joinpath(pkgdir(TradMod),\"data\")\n",
+    "DATA = readdlm(joinpath(datadir,\"WIOT08_ROW_Apr12.csv\"), ',', Float64)\n",
+    "epsilon = readdlm(joinpath(datadir,\"SECTORAL_TRADE_ELASTICITY.csv\"));\n"
    ]
   },
   {
@@ -74,57 +75,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Prepare data\n",
-      "Convert to zero deficit\n",
-      "Solve the model\n",
-      "Welfare correction\n",
-      "Output\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Table with 2 columns and 34 rows:\n",
-       "      Country  Welfare_effect\n",
-       "    ┌────────────────────────\n",
-       " 1  │ AUS      -0.283031\n",
-       " 2  │ AUT      -0.1318\n",
-       " 3  │ BEL      -0.256084\n",
-       " 4  │ BRA      -0.158406\n",
-       " 5  │ CAN      -2.27642\n",
-       " 6  │ CHN      -0.459308\n",
-       " 7  │ CZE      -0.0783826\n",
-       " 8  │ DEU      -0.203565\n",
-       " 9  │ DNK      -0.260493\n",
-       " 10 │ ESP      -0.0711924\n",
-       " 11 │ FIN      -0.0979161\n",
-       " 12 │ FRA      -0.127959\n",
-       " 13 │ GBR      -0.308883\n",
-       " 14 │ GRC      -0.0629793\n",
-       " 15 │ HUN      -0.167492\n",
-       " 16 │ IDN      -0.139234\n",
-       " 17 │ IND      -0.252024\n",
-       " 18 │ IRL      -1.57765\n",
-       " 19 │ ITA      -0.0697335\n",
-       " 20 │ JPN      -0.111689\n",
-       " 21 │ KOR      -0.33756\n",
-       " 22 │ MEX      -1.66997\n",
-       " 23 │ NLD      -0.339143\n",
-       " ⋮  │    ⋮           ⋮"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "t = runTradMod(DATA,elast = epsilon,country = \"USA\",tariff = 0.4)"
    ]
@@ -178,7 +131,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.8.0",
+   "display_name": "Julia 1.8.3",
    "language": "julia",
    "name": "julia-1.8"
   },
@@ -186,7 +139,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.8.0"
+   "version": "1.8.3"
   },
   "orig_nbformat": 4,
   "vscode": {


### PR DESCRIPTION
This is nicely done. One minor improvement is to use a relative path to the data, e.g. 
```julia
datadir = joinpath(pkgdir(TradMod),"data")
DATA = readdlm(joinpath(datadir,"WIOT08_ROW_Apr12.csv"), ',', Float64)
```

You also could consider following Julia's [suggested naming style](https://docs.julialang.org/en/v1/manual/style-guide/#Use-naming-conventions-consistent-with-Julia-base). 

Instead of passing in and returning such long tuples, it might be less error prone and more maintainable to create and use some custom structs.  

If faster performance is needed, I would guess there would be gains by moving away from Matlab style "vectorized" code to less memory intensive indexing. For example, in MLZ_TRF_SYSTEM_MANY_ARGS_FIXED_COSTS, there are many calls to `reshape`, `permutedims`, and especially, `repeat`. Some of these likely allocate memory. These allocations are likely costly and could be avoided.  I'm just guessing here, so, of course, the best thing would be to profile the code to find bottlenecks before making any changes. 